### PR TITLE
Use compiler pins only for 7.2 toolchain on x86

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,10 @@ source:
   sha256: 229393ab2bf0dc94694f21836846b424f3532585bac3468738b7bf752c03901e
 
 build:
-  number: 2
+  number: 3
   run_exports:
     # https://abi-laboratory.pro/tracker/timeline/libevent/
     - {{ pin_subpackage('libevent', max_pin='x.x') }}
-  ignore_run_exports:
-    - libgcc-ng
 
 requirements:
 
@@ -27,15 +25,10 @@ requirements:
     - libtool
     - {{ compiler('c') }}
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
+    - libgcc-ng  {{ libgcc }}           # [x86_64 and c_compiler_version == "7.2.*"]
   host:
     # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-  run:
-    # Will be taken care of by run_exports
-    # - openssl 1.0.*
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
+    - libgcc-ng  {{ libgcc }}           # [x86_64 and c_compiler_version == "7.2.*"]
 
 test:
   requires:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Adjusted libgcc pins to be enabled only for 7.2 toolchain on x86.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
